### PR TITLE
Removed trailing semi-colon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the generated Pushover application token to the services config file:
 ...
 'pushover' => [
     'token' => 'YOUR_APPLICATION_TOKEN',
-];
+],
 ...
 ```
 


### PR DESCRIPTION
It'd break the array. People are smart and know this, but thought it'd be a quick quality-of-life update.
