### PR TITLE
Allow backwards compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,8 @@
     "require": {
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/events": "5.3.*",
-        "illuminate/queue": "5.3.*",
         "illuminate/notifications": "5.3.*",
-        "illuminate/support": "5.3.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*",
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds backwards compatibility to make use of this notification channel with the `laravel-notification-channels/backport` package.
