### PR TITLE
allow a notifiable model to overrule the globally set token

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ public function routeNotificationForPushover() {
 }
 ```
 
-If you want to (dynamically) overrule the token from the services config file, e.g. because each user, company or any other notifiable model hold their own application token, return a `PushoverReceiver` object like this:
+If you want to (dynamically) overrule the application token from the services config, e.g. because each user holds their own application token, return a `PushoverReceiver` object like this:
 ```php
 ...
 public function routeNotificationForPushover() {
-    return PushoverReceiver::withUserKeyAndToken('pushover-key', 'pushover-token');
+    return PushoverReceiver::withUserKey('pushover-key')
+        ->withApplicationToken('app-token');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ public function routeNotificationForPushover() {
         ->toDevice(['iphone', 'desktop']);
 }
 ```
+
+If you want to (dynamically) overrule the token from the services config file, e.g. because each user, company or any other notifiable model hold their own application token, return a `PushoverReceiver` object like this:
+```php
+...
+public function routeNotificationForPushover() {
+    return PushoverReceiver::withUserKeyAndToken('pushover-key', 'pushover-token');
+}
+```
+
 You can also send a message to a Pushover group:
 ```php
 ...

--- a/src/Pushover.php
+++ b/src/Pushover.php
@@ -68,15 +68,15 @@ class Pushover
     }
 
     /**
-     * Merge token into parameters array.
+     * Merge token into parameters array, unless it has been set on the PushoverReceiver.
      *
      * @param  array  $params
      * @return array
      */
     protected function paramsWithToken($params)
     {
-        return array_merge($params, [
+        return array_merge([
             'token' => $this->token,
-        ]);
+        ], $params);
     }
 }

--- a/src/PushoverReceiver.php
+++ b/src/PushoverReceiver.php
@@ -79,15 +79,9 @@ class PushoverReceiver
      */
     public function toArray()
     {
-        $receiverArray = [
+        return array_merge([
             'user' => $this->key,
             'device' => implode(',', $this->devices),
-        ];
-
-        if ($this->token) {
-            $receiverArray['token'] = $this->token;
-        }
-
-        return $receiverArray;
+        ], $this->token ? ['token' => $this->token] : []);
     }
 }

--- a/src/PushoverReceiver.php
+++ b/src/PushoverReceiver.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\Pushover;
 class PushoverReceiver
 {
     protected $key;
+    protected $token;
     protected $devices = [];
 
     /**
@@ -59,15 +60,34 @@ class PushoverReceiver
     }
 
     /**
+     * Set the application token.
+     *
+     * @param $token
+     * @return PushoverReceiver
+     */
+    public function withApplicationToken($token)
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+
+    /**
      * Get array representation of Pushover receiver.
      *
      * @return array
      */
     public function toArray()
     {
-        return [
+        $receiverArray = [
             'user' => $this->key,
             'device' => implode(',', $this->devices),
         ];
+
+        if ($this->token) {
+            $receiverArray['token'] = $this->token;
+        }
+
+        return $receiverArray;
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -34,7 +34,7 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_can_send_a_pushover_notification()
+    public function it_can_send_a_pushover_notification_with_a_global_token()
     {
         $message = (new PushoverMessage('Message text'))
             ->title('Message title')
@@ -44,7 +44,7 @@ class IntegrationTest extends TestCase
             ->url('http://example.com', 'Example Website');
 
         $this->requestWillBeSentToPushoverWith([
-            'token' => 'application-token',
+            'token' => 'global-application-token',
             'user' => 'pushover-key',
             'device' => 'iphone,desktop',
             'message' => 'Message text',
@@ -58,13 +58,47 @@ class IntegrationTest extends TestCase
             'url_title' => 'Example Website',
         ]);
 
-        $pushover = new Pushover($this->guzzleClient, 'application-token');
+        $pushover = new Pushover($this->guzzleClient, 'global-application-token');
 
         $channel = new PushoverChannel($pushover, $this->events);
 
         $this->notification->shouldReceive('toPushover')->andReturn($message);
 
         $channel->send(new NotifiableWithPushoverReceiver, $this->notification);
+    }
+
+    /** @test */
+    public function it_can_send_a_pushover_notification_with_an_overridden_token()
+    {
+        $message = (new PushoverMessage('Message text'))
+            ->title('Message title')
+            ->emergencyPriority(60, 600)
+            ->time(123456789)
+            ->sound('boing')
+            ->url('http://example.com', 'Example Website');
+
+        $this->requestWillBeSentToPushoverWith([
+            'token' => 'overridden-application-token',
+            'user' => 'pushover-key',
+            'device' => 'iphone,desktop',
+            'message' => 'Message text',
+            'title' => 'Message title',
+            'priority' => 2,
+            'retry' => 60,
+            'expire' => 600,
+            'timestamp' => 123456789,
+            'sound' => 'boing',
+            'url' => 'http://example.com',
+            'url_title' => 'Example Website',
+        ]);
+
+        $pushover = new Pushover($this->guzzleClient, 'global-application-token');
+
+        $channel = new PushoverChannel($pushover, $this->events);
+
+        $this->notification->shouldReceive('toPushover')->andReturn($message);
+
+        $channel->send(new NotifiableWithPushoverReceiverWithToken(), $this->notification);
     }
 
     protected function requestWillBeSentToPushoverWith($params)

--- a/tests/NotifiableWithPushoverReceiverWithToken.php
+++ b/tests/NotifiableWithPushoverReceiverWithToken.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\Pushover\Test;
+
+use NotificationChannels\Pushover\PushoverReceiver;
+
+class NotifiableWithPushoverReceiverWithToken extends Notifiable
+{
+    public function routeNotificationFor($channel)
+    {
+        return PushoverReceiver::withUserKey('pushover-key')
+            ->withApplicationToken('overridden-application-token')
+            ->toDevice('iphone')
+            ->toDevice('desktop');
+    }
+}

--- a/tests/PushoverReceiverTest.php
+++ b/tests/PushoverReceiverTest.php
@@ -31,6 +31,24 @@ class PushoverReceiverTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_up_a_receiver_with_an_application_token()
+    {
+        $pushoverReceiver = PushoverReceiver::withUserKey('pushover-key')->withApplicationToken('pushover-token');
+
+        $this->assertArraySubset(['user' => 'pushover-key', 'token' => 'pushover-token'], $pushoverReceiver->toArray());
+    }
+
+    /** @test */
+    public function it_only_exposes_app_token_when_set()
+    {
+        $pushoverReceiverUserKey = PushoverReceiver::withUserKey('pushover-key');
+        $pushoverReceiverGroupKey = PushoverReceiver::withGroupKey('pushover-key');
+
+        $this->assertArrayNotHasKey('token', $pushoverReceiverUserKey->toArray());
+        $this->assertArrayNotHasKey('token', $pushoverReceiverGroupKey->toArray());
+    }
+
+    /** @test */
     public function it_can_add_a_single_device_to_the_receiver()
     {
         $this->pushoverReceiver->toDevice('iphone');

--- a/tests/PushoverTest.php
+++ b/tests/PushoverTest.php
@@ -41,6 +41,19 @@ class PushoverTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_a_request_with_an_overridden_token()
+    {
+        $this->guzzleClient->shouldReceive('post')
+            ->with('https://api.pushover.net/1/messages.json', [
+                'form_params' => [
+                    'token' => 'dynamic-application-token',
+                ],
+            ]);
+
+        $this->pushover->send(['token' => 'dynamic-application-token']);
+    }
+
+    /** @test */
     public function it_can_accept_parameters_for_a_send_request()
     {
         $this->guzzleClient->shouldReceive('post')


### PR DESCRIPTION
This PR adds an optional application token to the PushoverReceiver that will override the globally set token in the services config file.
In case it is not set, the global token will be used (so it's a non-breaking change).

It should allow building applications where users/tenants can use their own Pushover Account, instead of having to depend on the account of the application owner :)

Readme has been updated to describe the functionality as well!