### PR TITLE
Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "^1.0",
         "phpunit/phpunit": "~8.0",
         "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.2",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/notifications": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+        "illuminate/notifications": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "~4.4",
-        "orchestra/testbench": "~3.3|~3.4"
+        "phpunit/phpunit": "~8.0",
+        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "~8.0",
-        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8"
+        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8",
+        "dms/phpunit-arraysubset-asserts": ">=0.1.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -22,7 +22,7 @@ class IntegrationTest extends TestCase
     /** @var Dispatcher */
     protected $events;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PushoverChannelTest.php
+++ b/tests/PushoverChannelTest.php
@@ -30,7 +30,7 @@ class PushoverChannelTest extends TestCase
     /** @var Dispatcher */
     protected $events;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PushoverMessageTest.php
+++ b/tests/PushoverMessageTest.php
@@ -122,7 +122,7 @@ class PushoverMessageTest extends TestCase
     /** @test */
     public function it_cannot_set_priority_to_emergency_when_not_providing_a_retry_and_expiry_time()
     {
-        $this->setExpectedException(EmergencyNotificationRequiresRetryAndExpire::class);
+        $this->expectException(EmergencyNotificationRequiresRetryAndExpire::class);
 
         $this->message->priority(PushoverMessage::EMERGENCY_PRIORITY);
     }

--- a/tests/PushoverMessageTest.php
+++ b/tests/PushoverMessageTest.php
@@ -12,7 +12,7 @@ class PushoverMessageTest extends TestCase
     /** @var PushoverMessage */
     protected $message;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->message = new PushoverMessage();

--- a/tests/PushoverReceiverTest.php
+++ b/tests/PushoverReceiverTest.php
@@ -3,6 +3,8 @@
 namespace NotificationChannels\Pushover\Test;
 
 use Orchestra\Testbench\TestCase;
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use NotificationChannels\Pushover\PushoverReceiver;
 
 class PushoverReceiverTest extends TestCase
@@ -19,7 +21,7 @@ class PushoverReceiverTest extends TestCase
     {
         $pushoverReceiver = PushoverReceiver::withUserKey('pushover-key');
 
-        $this->assertArraySubset(['user' => 'pushover-key'], $pushoverReceiver->toArray());
+        Assert::assertArraySubset(['user' => 'pushover-key'], $pushoverReceiver->toArray());
     }
 
     /** @test */
@@ -27,7 +29,7 @@ class PushoverReceiverTest extends TestCase
     {
         $pushoverReceiver = PushoverReceiver::withGroupKey('pushover-key');
 
-        $this->assertArraySubset(['user' => 'pushover-key'], $pushoverReceiver->toArray());
+        Assert::assertArraySubset(['user' => 'pushover-key'], $pushoverReceiver->toArray());
     }
 
     /** @test */
@@ -35,7 +37,7 @@ class PushoverReceiverTest extends TestCase
     {
         $pushoverReceiver = PushoverReceiver::withUserKey('pushover-key')->withApplicationToken('pushover-token');
 
-        $this->assertArraySubset(['user' => 'pushover-key', 'token' => 'pushover-token'], $pushoverReceiver->toArray());
+        Assert::assertArraySubset(['user' => 'pushover-key', 'token' => 'pushover-token'], $pushoverReceiver->toArray());
     }
 
     /** @test */
@@ -53,7 +55,7 @@ class PushoverReceiverTest extends TestCase
     {
         $this->pushoverReceiver->toDevice('iphone');
 
-        $this->assertArraySubset(['device' => 'iphone'], $this->pushoverReceiver->toArray());
+        Assert::assertArraySubset(['device' => 'iphone'], $this->pushoverReceiver->toArray());
     }
 
     /** @test */
@@ -63,7 +65,7 @@ class PushoverReceiverTest extends TestCase
             ->toDevice('desktop')
             ->toDevice('macbook');
 
-        $this->assertArraySubset(['device' => 'iphone,desktop,macbook'], $this->pushoverReceiver->toArray());
+        Assert::assertArraySubset(['device' => 'iphone,desktop,macbook'], $this->pushoverReceiver->toArray());
     }
 
     /** @test */
@@ -71,6 +73,6 @@ class PushoverReceiverTest extends TestCase
     {
         $this->pushoverReceiver->toDevice(['iphone', 'desktop', 'macbook']);
 
-        $this->assertArraySubset(['device' => 'iphone,desktop,macbook'], $this->pushoverReceiver->toArray());
+        Assert::assertArraySubset(['device' => 'iphone,desktop,macbook'], $this->pushoverReceiver->toArray());
     }
 }

--- a/tests/PushoverReceiverTest.php
+++ b/tests/PushoverReceiverTest.php
@@ -9,7 +9,7 @@ class PushoverReceiverTest extends TestCase
 {
     private $pushoverReceiver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->pushoverReceiver = PushoverReceiver::withUserKey('pushover-key');
     }

--- a/tests/PushoverServiceProviderTest.php
+++ b/tests/PushoverServiceProviderTest.php
@@ -17,7 +17,7 @@ class PushoverServiceProviderTest extends TestCase
     /** @var Application */
     protected $app;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PushoverTest.php
+++ b/tests/PushoverTest.php
@@ -19,7 +19,7 @@ class PushoverTest extends TestCase
     /** @var HttpClient */
     protected $guzzleClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PushoverTest.php
+++ b/tests/PushoverTest.php
@@ -72,7 +72,8 @@ class PushoverTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_pushover_returns_an_error_with_invalid_json()
     {
-        $this->setExpectedException(CouldNotSendNotification::class, 'Pushover responded with an error (400).');
+        $this->expectException(CouldNotSendNotification::class);
+        $this->expectExceptionMessage('Pushover responded with an error (400).');
 
         $guzzleRequest = Mockery::mock(\Psr\Http\Message\RequestInterface::class);
         $guzzleResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
@@ -87,7 +88,8 @@ class PushoverTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_pushover_returns_an_error_with_valid_json()
     {
-        $this->setExpectedException(CouldNotSendNotification::class, 'Pushover responded with an error (400): error_message_1, error_message_2');
+        $this->expectException(CouldNotSendNotification::class);
+        $this->expectExceptionMessage('Pushover responded with an error (400): error_message_1, error_message_2');
 
         $guzzleRequest = Mockery::mock(\Psr\Http\Message\RequestInterface::class);
         $guzzleResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
@@ -102,7 +104,8 @@ class PushoverTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_pushover_returns_nothing()
     {
-        $this->setExpectedException(ServiceCommunicationError::class, 'The communication with Pushover failed because');
+        $this->expectException(ServiceCommunicationError::class);
+        $this->expectExceptionMessage('The communication with Pushover failed because');
 
         $guzzleRequest = Mockery::mock(\Psr\Http\Message\RequestInterface::class);
 
@@ -114,7 +117,8 @@ class PushoverTest extends TestCase
     /** @test */
     public function it_throws_an_exception_when_an_unknown_communication_error_occurred()
     {
-        $this->setExpectedException(ServiceCommunicationError::class, 'The communication with Pushover failed');
+        $this->expectException(ServiceCommunicationError::class);
+        $this->expectExceptionMessage('The communication with Pushover failed');
 
         $this->guzzleClient->shouldReceive('post')->andThrow(new Exception);
 


### PR DESCRIPTION
### Changes
- Adding support for Laravel 5.8
- Removing support for Laravel 5.3 and 5.4 **(see notes)**
- Restricting PHP Version to 7.2 or above as per https://laravel.com/docs/5.8/installation and https://phpunit.de/announcements/phpunit-8.html
- Upping PHPUnit requirement to `~8.0`. Laravel 5.8 still technically supports PHPUnit 7 - but Laravel 5.9 very likely won't due to PHP Version requirement changes.
- Upping `mockery` requirement to `^1.0`
- Added dms/phpunit-arraysubset-asserts to `require-dev` due to `assertArraySubset` being deprecated in PHPUnit 9.
- Fixed deprecated method calls in unit tests.

### Notes:
Compatibility with older orchestra/testbench releases has to go if we want to use newer PHPUnit versions.
Furthermore, this release should (in my opinion) stop supporting PHP 5.6, 7.0 and 7.1 - all of which are EOL.

### Fixes:
This fixes #29.