### PR TITLE
Update nesbot/carbon to ^1.26.3 || ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "guzzlehttp/guzzle": "^6.2",
         "illuminate/notifications": "5.5.*|5.6.*|5.7.*|5.8.*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "nesbot/carbon": "^1.21"
+        "nesbot/carbon": "^1.26.3 || ^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Laravel 5.8 uses nesbot/carbon version ^1.26.3 || ^2.0

See https://github.com/laravel-notification-channels/pushover/issues/32 for more details