### PR TITLE
CouldNotSendNotification returns $statusCode and information about $notifiable

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -7,16 +7,26 @@ use Psr\Http\Message\ResponseInterface;
 
 class CouldNotSendNotification extends Exception
 {
-    public static function serviceRespondedWithAnError(ResponseInterface $response)
+    public static function serviceRespondedWithAnError(ResponseInterface $response, $notifiable)
     {
         $statusCode = $response->getStatusCode();
 
         $result = json_decode($response->getBody());
 
+        $exceptionMessage = sprintf(
+            "Pushover responded with an error (%s) for notifiable '%s' with id '%s'",
+            $statusCode,
+            get_class($notifiable),
+            $notifiable->getKey()
+        );
+
         if ($result && isset($result->errors)) {
-            return new static('Pushover responded with an error ('.$statusCode.'): '.implode(', ', $result->errors));
+            $exceptionMessage = sprintf(
+                "$exceptionMessage: %s",
+                implode(', ', $result->errors)
+            );
         }
 
-        return new static('Pushover responded with an error ('.$statusCode.').');
+        return new static($exceptionMessage, $statusCode);
     }
 }

--- a/src/Pushover.php
+++ b/src/Pushover.php
@@ -59,7 +59,9 @@ class Pushover
             ]);
         } catch (RequestException $exception) {
             if ($exception->getResponse()) {
-                throw CouldNotSendNotification::serviceRespondedWithAnError($exception->getResponse());
+                throw CouldNotSendNotification::serviceRespondedWithAnError(
+                    $exception->getResponse(), $notifiable
+                );
             }
             throw ServiceCommunicationError::communicationFailed($exception);
         } catch (Exception $exception) {


### PR DESCRIPTION
When for example we bulk send notification with many recipients like this:
```php
Notification::send(
    $recipients,
    new Notification()
);
````
and we got the exception message `Pushover responded with an error (400): user identifier is not a valid user, group, or subscribed user key` we would not know which recipient had the wrong `pushover_key`. Now, with modified `CouldNotSendNotification` we would be able to read the notfiable model and id.