### PR TITLE
Change not supported fire() to dispatch()

### DIFF
--- a/src/PushoverChannel.php
+++ b/src/PushoverChannel.php
@@ -55,7 +55,7 @@ class PushoverChannel
 
     protected function fireFailedEvent($notifiable, $notification, $message)
     {
-        $this->events->fire(
+        $this->events->dispatch(
             new NotificationFailed($notifiable, $notification, 'pushover', [$message])
         );
     }


### PR DESCRIPTION
Fire() is not longer supported and raises an error. It needs to be replaced by dispatch()