### PR TITLE
fixed missing $notifiable in send() method in Pushover

### DIFF
--- a/src/Pushover.php
+++ b/src/Pushover.php
@@ -55,11 +55,12 @@ class Pushover
      * @link  https://pushover.net/api
      *
      * @param  array  $params
+     * @param mixed $notifiable
      * @return \Psr\Http\Message\ResponseInterface
      *
      * @throws CouldNotSendNotification
      */
-    public function send($params)
+    public function send($params, $notifiable)
     {
         try {
             $multipart = [];

--- a/src/PushoverChannel.php
+++ b/src/PushoverChannel.php
@@ -47,7 +47,10 @@ class PushoverChannel
         $message = $notification->toPushover($notifiable);
 
         try {
-            $this->pushover->send(array_merge($message->toArray(), $pushoverReceiver->toArray()));
+            $this->pushover->send(
+                array_merge($message->toArray(), $pushoverReceiver->toArray()),
+                $notifiable
+            );
         } catch (ServiceCommunicationError $serviceCommunicationError) {
             $this->fireFailedEvent($notifiable, $notification, $serviceCommunicationError->getMessage());
         }


### PR DESCRIPTION
We already passed `$notifiable` to `CouldNotSendNotification::serviceRespondedWithAnError()` but unfortunately it was not defined in the `send()` context in `Pushover` class. This PR fixes this and `$notifiable` is passed to `Pushover` from the `PushoverChannel` class.